### PR TITLE
Updated the table_columns Function Grammar

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -64,7 +64,7 @@ export default [
   "sum",
   "sysdate",
   "systimestamp",
-  "tables_columns",
+  "table_columns",
   "timestamp_ceil",
   "timestamp_floor",
   "timestamp_sequence",


### PR DESCRIPTION
Updated the tables_columns to ==> table_columns per the documentation and also testing this using the Web Console. The intellisense incorrectly shows tables_columns. 

https://questdb.io/docs/reference/function/meta/#table_columns